### PR TITLE
systemd: add Documentation key to the template unit

### DIFF
--- a/share/gpiod-sysfs-proxy@.service
+++ b/share/gpiod-sysfs-proxy@.service
@@ -20,6 +20,7 @@
 
 [Unit]
 Description=User-space, libgpiod-based GPIO sysfs compatibility layer at %I
+Documentation=https://github.com/brgl/gpiod-sysfs-proxy
 
 [Service]
 RuntimeDirectory=gpio


### PR DESCRIPTION
In the Debian packaging, lintian emits systemd-service-file-missing-documentation-key because the unit has no Documentation= directive set. Point it at the project's homepage so `systemctl status` and the lintian check are satisfied.